### PR TITLE
fix slice glitch

### DIFF
--- a/Assets/Scripts/Slice.cs
+++ b/Assets/Scripts/Slice.cs
@@ -71,6 +71,7 @@ public class Slice : MonoBehaviour
 		doll.GetComponent<DollAnimationController> ().Slice ();
 
 		doll.layer = 0;
+		doll.GetComponent<Rigidbody2D> ().constraints = RigidbodyConstraints2D.FreezePositionX | RigidbodyConstraints2D.FreezePositionY;
 		manager.dollsUpdated = false;
 		manager.updateDolls ();
 


### PR DESCRIPTION
For some reason slicing makes the doll move around, I'm locking the sliced doll position since it's only  going to play sliced animation and die
