### PR TITLE
Fixed the bug where you cannot progress the dialog after quiting the game from the pause screen.

### DIFF
--- a/Assets/Scripts/UI/PauseScrn/Navigation.cs
+++ b/Assets/Scripts/UI/PauseScrn/Navigation.cs
@@ -55,6 +55,7 @@ public class Navigation : MonoBehaviour
 
 	public void selectQuit(){
         resetSelection();
+        GameManager.getInstance().isPaused = false; //Set paused to false as you exit the pause screen when exiting the game. 
         SceneManager.LoadScene("NewTitleScene");
 	}
 


### PR DESCRIPTION
Fixed this bug: https://trello.com/c/7i5VlETH/217-z-to-progress-dialogue-doesn-t-work-when-restarting-game
Basically we were not resetting the isPaused boolean back to false.
Tested and now the bug does not happen. 
